### PR TITLE
Use https

### DIFF
--- a/lockdown.js
+++ b/lockdown.js
@@ -145,7 +145,7 @@ exec('npm config get registry', function(err, stdout, stderr) {
     }
 
     var hash = crypto.createHash('sha1');
-    var pkgUrl = url.resolve(registry.href, req.url);
+    var pkgUrl = registry.href + req.url.substr(1);
 
     if (type === 'tarball') {
       npmClient.fetch(pkgUrl, { timeout: 2000 }, function(err, rres) {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   ],
   "dependencies": {
     "lodash": "^4.8.2",
-    "npm-registry-client": "^7.1.0",
     "npmconf": "1.1.5",
     "osenv": "0.1.0",
     "read-installed": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "Sean McArthur <sean.monstar@gmail.com> (http://seanmonstar.com)"
   ],
   "dependencies": {
+    "lodash": "^4.8.2",
     "npm-registry-client": "^7.1.0",
     "npmconf": "1.1.5",
     "osenv": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -13,9 +13,11 @@
     "Sean McArthur <sean.monstar@gmail.com> (http://seanmonstar.com)"
   ],
   "dependencies": {
+    "npm-registry-client": "^7.1.0",
     "npmconf": "1.1.5",
     "osenv": "0.1.0",
-    "read-installed": "3.1.0"
+    "read-installed": "3.1.0",
+    "silent-npm-registry-client": "^2.1.0"
   },
   "engines": {
     "node": ">=0.6.17"


### PR DESCRIPTION
NPM switched totally over to HTTPS. This caused the existing raw http requests to start failing.

This change moves to `silent-npm-registry-client` for more concise code. It also updates the `relock` script to accept an optional space-delimited list of packages to lock down. This is useful for updating your `lockdown.json` after installing a single new package for instance:

`npm install some-new-dep && lockdown-relock some-new-dep`
